### PR TITLE
[EAG-855] Add initial logic to hide/show a menu option from a node's context menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ npm-debug.log
 /spec/temp/
 /coverage
 package-lock.json
+
+# Mac files
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carecloud/the-graph",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "flow-based programming graph editing",
   "author": "Forrest Oliphant, the Grid",
   "license": "MIT",
@@ -16,7 +16,6 @@
     "font-awesome": "^4.6.3",
     "hammerjs": "^2.0.8",
     "klayjs-noflo": "^0.3.1",
-    "phantomjs": "^2.1.7",
     "tv4": "^1.3.0",
     "yargs": "^10.0.3"
   },
@@ -44,7 +43,8 @@
     "react": "^15.6.2",
     "react-dom": "^15.6.2",
     "react-test-renderer": "^15.6.2",
-    "stylus": "~0.54.5"
+    "stylus": "~0.54.5",
+    "phantomjs": "^2.1.7"
   },
   "scripts": {
     "start": "grunt dev",

--- a/the-graph/the-graph-menu.js
+++ b/the-graph/the-graph-menu.js
@@ -143,14 +143,13 @@ var Menu = React.createFactory( createReactClass({
 
     Object.keys(this.props.menu).forEach(
         function (direction) {
-          var directionObj = self.props.menu[direction];
+          var dir = self.props.menu[direction];
           var key = direction + 'tappable';
+          var hasVisibleCallback = dir.isVisible && (typeof dir.isVisible === 'function');
 
-          // If visibility is set for a given direction, check if the current node should be able to see it.
-          if (!directionObj.isVisible) {
-            initialState[key] = directionObj.action;
-          } else if (directionObj.isVisible(self.props.options)) {
-            initialState[key] = directionObj.action;
+          // If `isVisible` is set for a given direction, check if the current node should be able to see it.
+          if (!hasVisibleCallback || dir.isVisible(self.props.options)) {
+            initialState[key] = dir.action;
           }
         }
     );


### PR DESCRIPTION
**Ticket:** https://jira.carecloud.com/browse/EAG-855
**Changes:**
 - Add the capability to set a callback function to each context menu option. This callback will defined, by returning a boolean, if a given node should see or not the option.
   - This feature can be used to enable certain options to appear on special nodes.